### PR TITLE
Place integration test credentials into separate environment

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,7 +3,7 @@ on:
     types: [created]
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 env:
@@ -46,7 +46,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    environment: production
+    environment: pull-request
     needs:
     - package
 


### PR DESCRIPTION
Once the repository secrets are cleaned up after accepting this we should be able to safely run integration tests on pull requests.