### PR TITLE
Adding ability to install auxiliary apps

### DIFF
--- a/lib/schedule-run.js
+++ b/lib/schedule-run.js
@@ -71,6 +71,34 @@ exports.scheduleRun = async function (params) {
         }
     }
 
+    if (params.auxiliaryApps) {
+        try {
+            core.info("Uploading auxiliary app(s)");
+            params.configuration = { auxiliaryApps: [] };
+            const appsToInstall = [];
+            if (typeof params.auxiliaryApps === "string") {
+                appsToInstall.push(params.auxiliaryApps);
+
+            } else if (typeof params.auxiliaryApps === "object" && params.auxiliaryApps !== null && Array.isArray(params.auxiliaryApps)) {
+                appsToInstall = params.auxiliaryApps;
+            } else {
+               throw("Illegal argument " + params.auxiliaryApps) 
+            }
+
+            for (const auxApp of appsToInstall) {
+                var app = await file_upload.uploadFile({
+                    projectArn: params.projectArn,
+                    remote_src: params.remote_src,
+                    type: params.appType,
+                    file: auxApp
+                });
+                params.configuration.auxiliaryApps.push(app.upload.arn);
+            }
+        } catch (err) {
+            throw("Unable to publish auxiliary app file " + params.auxiliaryApps + ", " + err);
+        }
+    }
+
     if (params.testSpecFile) {
         if (params.test_spec) {
             core.info(`Using inline test_spec. Writing it to ${params.testSpecFile}`);
@@ -123,6 +151,7 @@ exports.scheduleRun = async function (params) {
 
     var run_params = {
         appArn: params.appArn,
+        configuration: params.configuration,
         name: name,
         devicePoolArn: params.devicePoolArn,
         projectArn: params.projectArn,

--- a/test-application/action.yml
+++ b/test-application/action.yml
@@ -11,6 +11,9 @@ inputs:
   app_file:
     description: 'Full path to a file to upload and use as app'
     required: false
+  app_auxiliary_files:
+    description: 'Full path to an auxiliary files to upload'
+    required: false  
   app_type:
     description: 'Type of the app file'
     required: false

--- a/test-application/index.js
+++ b/test-application/index.js
@@ -10,6 +10,7 @@ params.name = core.getInput('name');
 
 params.appArn = core.getInput('app_arn');
 params.appFile = core.getInput('app_file');
+params.auxiliaryApps = core.getInput('app_auxiliary_files');
 params.appType = core.getInput('app_type');
 
 params.timeout = core.getInput('timeout');


### PR DESCRIPTION
Some Tests setup requires the existence of other apps on the device. 
This PR support the auxiliaryApps configuration parameter which will upload the configured apps prior to the test execution.
This is currently used in https://github.com/realm/realm-kotlin/pull/1605/files#diff-604f50a605b704c73aa4474fbdb263cda70a027db332d04bab7d464fdc042176R29 