### PR TITLE
Add outputs for schedule run.

### DIFF
--- a/lib/schedule-run.js
+++ b/lib/schedule-run.js
@@ -130,6 +130,7 @@ exports.scheduleRun = async function (params) {
     }
 
     var run = await devicefarm.scheduleRun(run_params);
+    core.setOutput("arn", run.run.arn)
 
     var run_status;
     var i;
@@ -172,6 +173,7 @@ exports.scheduleRun = async function (params) {
                                                             arn: run.run.arn});
 
     if (run_status.run.result != "PASSED") {
+        core.setOutput("result", run_status.run.result);
         throw("Test run failed after " + i*wait_interval + " seconds with: " + run_status.run.resultCode + ". Timeout is set to " + max_wait*wait_interval);
     }
 


### PR DESCRIPTION
source: https://github.com/realm/aws-devicefarm/pull/17/files
fixing arn not being reported on failure.